### PR TITLE
Fix build errors by creating 'obj' directory and adding string.h to communication.c

### DIFF
--- a/firmware/Communication.c
+++ b/firmware/Communication.c
@@ -1,5 +1,5 @@
 #include <stdbool.h>
-
+#include <string.h>
 #include "Config/DancePadConfig.h"
 #include "Communication.h"
 #include "Pad.h"

--- a/firmware/build/makefile
+++ b/firmware/build/makefile
@@ -25,7 +25,7 @@ CC_FLAGS     = -DUSE_LUFA_CONFIG_HEADER -I../Config/ -I.. -DBOARD_TYPE_$(BOARD_T
 LD_FLAGS     =
 
 # Default target
-all:
+all: | $(shell mkdir -p obj)
 
 # Include LUFA-specific DMBS extension modules
 DMBS_LUFA_PATH ?= $(LUFA_PATH)/Build/LUFA


### PR DESCRIPTION
1. "No such file or directory" error for obj/Communication.o:

Add a rule in the `Makefile` to create the `obj` directory if it doesn't exist.

2. Implicit function declaration warnings for `memset` and `strcpy` in `communication.c`:

Add `#include <string.h>` at the top of Communication.c.


